### PR TITLE
Updated require:neos-ui and fixed misspelling

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -25,7 +25,7 @@
 #              label: 'Large'
 #              cssClass: 'my-class-size-large'
 #            '':
-#              label: 'unset color'
+#              label: 'unset size'
 #              cssClass: null
 
 Neos:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "neos/neos-ui": ">=3.8 <4.0"
+        "neos/neos-ui": ">=3.8 <6.0"
     },
     "extra": {
         "neos": {


### PR DESCRIPTION
Updated required neos-ui version >=3.8 <6.0.
Fixed mistake in writing.